### PR TITLE
Fixes for Frodo 12.3

### DIFF
--- a/resources/lib/kodion/impl/xbmc/xbmc_items.py
+++ b/resources/lib/kodion/impl/xbmc/xbmc_items.py
@@ -18,6 +18,7 @@ def to_video_item(context, video_item):
         fanart = video_item.get_fanart()
     if major_version <= 12:
         item.setIconImage(thumb)
+        item.setProperty("Fanart_Image", fanart)
     elif major_version <= 15:
         item.setArt({'thumb': thumb, 'fanart': fanart})
         item.setIconImage(thumb)
@@ -62,6 +63,7 @@ def to_audio_item(context, audio_item):
         fanart = audio_item.get_fanart()
     if major_version <= 12:
         item.setIconImage(thumb)
+        item.setProperty("Fanart_Image", fanart)
     elif major_version <= 15:
         item.setArt({'thumb': thumb, 'fanart': fanart})
         item.setIconImage(thumb)

--- a/resources/lib/kodion/impl/xbmc/xbmc_items.py
+++ b/resources/lib/kodion/impl/xbmc/xbmc_items.py
@@ -16,7 +16,9 @@ def to_video_item(context, video_item):
     item = xbmcgui.ListItem(label=title)
     if video_item.get_fanart() and settings.show_fanart():
         fanart = video_item.get_fanart()
-    if major_version <= 15:
+    if major_version <= 12:
+        item.setIconImage(thumb)
+    elif major_version <= 15:
         item.setArt({'thumb': thumb, 'fanart': fanart})
         item.setIconImage(thumb)
     else:
@@ -58,7 +60,9 @@ def to_audio_item(context, audio_item):
     item = xbmcgui.ListItem(label=title)
     if audio_item.get_fanart() and settings.show_fanart():
         fanart = audio_item.get_fanart()
-    if major_version <= 15:
+    if major_version <= 12:
+        item.setIconImage(thumb)
+    elif major_version <= 15:
         item.setArt({'thumb': thumb, 'fanart': fanart})
         item.setIconImage(thumb)
     else:


### PR DESCRIPTION
Seems that Frodo 12.3 doesn't support the 'setArt' attribute in 'xbmcgui.ListItem', so this patch adds a check to avoid it.

`AttributeError: 'xbmcgui.ListItem' object has no attribute 'setArt'`