### PR TITLE
Expose time since published for videos as item property

### DIFF
--- a/resources/language/resource.language.bg_bg/strings.po
+++ b/resources/language/resource.language.bg_bg/strings.po
@@ -862,7 +862,7 @@ msgctxt "#30648"
 msgid "API Key is incorrect. Settings - API - API Key"
 msgstr ""
 
-msgctxt "#30649
+msgctxt "#30649"
 msgid "Client Id is incorrect. Settings - API - API Id"
 msgstr ""
 
@@ -968,4 +968,40 @@ msgstr ""
 
 msgctxt "#30675"
 msgid "Use playback history (watched, resume tracking)"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Just now"
+msgstr ""
+
+msgctxt "#30677"
+msgid "A minute ago"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Recently"
+msgstr ""
+
+msgctxt "#30679"
+msgid "An hour ago"
+msgstr ""
+
+msgctxt "#30680"
+msgid "Two hours ago"
+msgstr ""
+
+msgctxt "#30681"
+msgid "Three hours ago"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Yesterday at"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Two days ago"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Today at"
 msgstr ""

--- a/resources/language/resource.language.cs_cz/strings.po
+++ b/resources/language/resource.language.cs_cz/strings.po
@@ -866,7 +866,7 @@ msgctxt "#30648"
 msgid "API Key is incorrect. Settings - API - API Key"
 msgstr ""
 
-msgctxt "#30649
+msgctxt "#30649"
 msgid "Client Id is incorrect. Settings - API - API Id"
 msgstr ""
 
@@ -972,4 +972,40 @@ msgstr ""
 
 msgctxt "#30675"
 msgid "Use playback history (watched, resume tracking)"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Just now"
+msgstr ""
+
+msgctxt "#30677"
+msgid "A minute ago"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Recently"
+msgstr ""
+
+msgctxt "#30679"
+msgid "An hour ago"
+msgstr ""
+
+msgctxt "#30680"
+msgid "Two hours ago"
+msgstr ""
+
+msgctxt "#30681"
+msgid "Three hours ago"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Yesterday at"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Two days ago"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Today at"
 msgstr ""

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -862,7 +862,7 @@ msgctxt "#30648"
 msgid "API Key is incorrect. Settings - API - API Key"
 msgstr ""
 
-msgctxt "#30649
+msgctxt "#30649"
 msgid "Client Id is incorrect. Settings - API - API Id"
 msgstr ""
 
@@ -969,3 +969,39 @@ msgstr ""
 msgctxt "#30675"
 msgid "Use playback history (watched, resume tracking)"
 msgstr ""
+
+msgctxt "#30676"
+msgid "Just now"
+msgstr "Jetzt"
+
+msgctxt "#30677"
+msgid "A minute ago"
+msgstr "Vor einer Minute"
+
+msgctxt "#30678"
+msgid "Recently"
+msgstr "Kürzlich"
+
+msgctxt "#30679"
+msgid "An hour ago"
+msgstr "Vor einer Stunde"
+
+msgctxt "#30680"
+msgid "Two hours ago"
+msgstr "Vor zwei Stunden"
+
+msgctxt "#30681"
+msgid "Three hours ago"
+msgstr "Vor drei Stunden"
+
+msgctxt "#30682"
+msgid "Yesterday at"
+msgstr "Gestern um"
+
+msgctxt "#30683"
+msgid "Two days ago"
+msgstr "Vorgestern"
+
+msgctxt "#30684"
+msgid "Today at"
+msgstr "Heute um"

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -238,7 +238,7 @@ msgstr "Διαγραφή \"%s\"?"
 
 msgctxt "#30117"
 msgid "Remove \"%s\"?"
-msgstr "Αφαίρεση \"%s\"?""
+msgstr "Αφαίρεση \"%s\"?"
 
 msgctxt "#30118"
 msgid "Delete"
@@ -878,7 +878,7 @@ msgctxt "#30648"
 msgid "API Key is incorrect. Settings - API - API Key"
 msgstr "Τα κλειδί API είναι λανθασμένο. Ρυθμίσεις - API - Κλειδί API"
 
-msgctxt "#30649
+msgctxt "#30649"
 msgid "Client Id is incorrect. Settings - API - API Id"
 msgstr "Τα αναγνωριστικό πελάτη είναι λανθασμένο. Ρυθμίσεις - API - Αναγνωριστικό API"
 
@@ -984,4 +984,40 @@ msgstr ""
 
 msgctxt "#30675"
 msgid "Use playback history (watched, resume tracking)"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Just now"
+msgstr ""
+
+msgctxt "#30677"
+msgid "A minute ago"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Recently"
+msgstr ""
+
+msgctxt "#30679"
+msgid "An hour ago"
+msgstr ""
+
+msgctxt "#30680"
+msgid "Two hours ago"
+msgstr ""
+
+msgctxt "#30681"
+msgid "Three hours ago"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Yesterday at"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Two days ago"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Today at"
 msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -879,7 +879,7 @@ msgctxt "#30648"
 msgid "API Key is incorrect. Settings - API - API Key"
 msgstr ""
 
-msgctxt "#30649
+msgctxt "#30649"
 msgid "Client Id is incorrect. Settings - API - API Id"
 msgstr ""
 
@@ -985,4 +985,40 @@ msgstr ""
 
 msgctxt "#30675"
 msgid "Use playback history (watched, resume tracking)"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Just now"
+msgstr ""
+
+msgctxt "#30677"
+msgid "A minute ago"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Recently"
+msgstr ""
+
+msgctxt "#30679"
+msgid "An hour ago"
+msgstr ""
+
+msgctxt "#30680"
+msgid "Two hours ago"
+msgstr ""
+
+msgctxt "#30681"
+msgid "Three hours ago"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Yesterday at"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Two days ago"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Today at"
 msgstr ""

--- a/resources/language/resource.language.en_us/strings.po
+++ b/resources/language/resource.language.en_us/strings.po
@@ -880,7 +880,7 @@ msgctxt "#30648"
 msgid "API Key is incorrect. Settings - API - API Key"
 msgstr ""
 
-msgctxt "#30649
+msgctxt "#30649"
 msgid "Client Id is incorrect. Settings - API - API Id"
 msgstr ""
 
@@ -986,4 +986,40 @@ msgstr ""
 
 msgctxt "#30675"
 msgid "Use playback history (watched, resume tracking)"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Just now"
+msgstr ""
+
+msgctxt "#30677"
+msgid "A minute ago"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Recently"
+msgstr ""
+
+msgctxt "#30679"
+msgid "An hour ago"
+msgstr ""
+
+msgctxt "#30680"
+msgid "Two hours ago"
+msgstr ""
+
+msgctxt "#30681"
+msgid "Three hours ago"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Yesterday at"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Two days ago"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Today at"
 msgstr ""

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -879,7 +879,7 @@ msgctxt "#30648"
 msgid "API Key is incorrect. Settings - API - API Key"
 msgstr "La clave API es incorrecta. Ajustes - API - API Key"
 
-msgctxt "#30649
+msgctxt "#30649"
 msgid "Client Id is incorrect. Settings - API - API Id"
 msgstr "La ID de cliente es incorrecta. Ajustes - API - API ID"
 
@@ -985,4 +985,40 @@ msgstr ""
 
 msgctxt "#30675"
 msgid "Use playback history (watched, resume tracking)"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Just now"
+msgstr ""
+
+msgctxt "#30677"
+msgid "A minute ago"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Recently"
+msgstr ""
+
+msgctxt "#30679"
+msgid "An hour ago"
+msgstr ""
+
+msgctxt "#30680"
+msgid "Two hours ago"
+msgstr ""
+
+msgctxt "#30681"
+msgid "Three hours ago"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Yesterday at"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Two days ago"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Today at"
 msgstr ""

--- a/resources/language/resource.language.fi_fi/strings.po
+++ b/resources/language/resource.language.fi_fi/strings.po
@@ -225,11 +225,11 @@ msgid "Confirm remove"
 msgstr "Varmista poisto"
 
 msgctxt "#30116"
-msgid "Delete "%s"?"
+msgid "Delete \"%s\"?"
 msgstr "Poistetaanko \"%s\"?"
 
 msgctxt "#30117"
-msgid "Remove "%s"?"
+msgid "Remove \"%s\"?"
 msgstr "Poistetaanko \"%s\"?"
 
 msgctxt "#30118"
@@ -864,7 +864,7 @@ msgctxt "#30648"
 msgid "API Key is incorrect. Settings - API - API Key"
 msgstr ""
 
-msgctxt "#30649
+msgctxt "#30649"
 msgid "Client Id is incorrect. Settings - API - API Id"
 msgstr ""
 
@@ -970,4 +970,40 @@ msgstr ""
 
 msgctxt "#30675"
 msgid "Use playback history (watched, resume tracking)"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Just now"
+msgstr ""
+
+msgctxt "#30677"
+msgid "A minute ago"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Recently"
+msgstr ""
+
+msgctxt "#30679"
+msgid "An hour ago"
+msgstr ""
+
+msgctxt "#30680"
+msgid "Two hours ago"
+msgstr ""
+
+msgctxt "#30681"
+msgid "Three hours ago"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Yesterday at"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Two days ago"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Today at"
 msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -225,12 +225,12 @@ msgid "Confirm remove"
 msgstr "Confirmer la suppression"
 
 msgctxt "#30116"
-msgid "Delete "%s"?"
-msgstr "Supprimer "%s"?"
+msgid "Delete \"%s\"?"
+msgstr "Supprimer \"%s\"?"
 
 msgctxt "#30117"
-msgid "Remove "%s"?"
-msgstr "Supprimer "%s" ?"
+msgid "Remove \"%s\"?"
+msgstr "Supprimer \"%s\" ?"
 
 msgctxt "#30118"
 msgid "Delete"
@@ -550,7 +550,7 @@ msgstr "Êtes-vous sûr de vouloir supprimer '%s' comme liste 'Regarder plus tar
 
 msgctxt "#30570"
 msgid "Are you sure you want to replace your current Watch Later list with '%s'?"
-msgstr "Êtes-vous sûr de vouloir remplacer votre liste 'Regarder plus tard' avec "%s" ?"
+msgstr "Êtes-vous sûr de vouloir remplacer votre liste 'Regarder plus tard' avec \"%s\" ?"
 
 msgctxt "#30571"
 msgid "Set as History"
@@ -864,7 +864,7 @@ msgctxt "#30648"
 msgid "API Key is incorrect. Settings - API - API Key"
 msgstr ""
 
-msgctxt "#30649
+msgctxt "#30649"
 msgid "Client Id is incorrect. Settings - API - API Id"
 msgstr ""
 
@@ -970,4 +970,40 @@ msgstr ""
 
 msgctxt "#30675"
 msgid "Use playback history (watched, resume tracking)"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Just now"
+msgstr ""
+
+msgctxt "#30677"
+msgid "A minute ago"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Recently"
+msgstr ""
+
+msgctxt "#30679"
+msgid "An hour ago"
+msgstr ""
+
+msgctxt "#30680"
+msgid "Two hours ago"
+msgstr ""
+
+msgctxt "#30681"
+msgid "Three hours ago"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Yesterday at"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Two days ago"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Today at"
 msgstr ""

--- a/resources/language/resource.language.he_il/strings.po
+++ b/resources/language/resource.language.he_il/strings.po
@@ -873,7 +873,7 @@ msgctxt "#30648"
 msgid "API Key is incorrect. Settings - API - API Key"
 msgstr ""
 
-msgctxt "#30649
+msgctxt "#30649"
 msgid "Client Id is incorrect. Settings - API - API Id"
 msgstr ""
 
@@ -979,4 +979,40 @@ msgstr ""
 
 msgctxt "#30675"
 msgid "Use playback history (watched, resume tracking)"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Just now"
+msgstr ""
+
+msgctxt "#30677"
+msgid "A minute ago"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Recently"
+msgstr ""
+
+msgctxt "#30679"
+msgid "An hour ago"
+msgstr ""
+
+msgctxt "#30680"
+msgid "Two hours ago"
+msgstr ""
+
+msgctxt "#30681"
+msgid "Three hours ago"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Yesterday at"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Two days ago"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Today at"
 msgstr ""

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -861,7 +861,7 @@ msgctxt "#30648"
 msgid "API Key is incorrect. Settings - API - API Key"
 msgstr ""
 
-msgctxt "#30649
+msgctxt "#30649"
 msgid "Client Id is incorrect. Settings - API - API Id"
 msgstr ""
 
@@ -967,4 +967,40 @@ msgstr ""
 
 msgctxt "#30675"
 msgid "Use playback history (watched, resume tracking)"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Just now"
+msgstr ""
+
+msgctxt "#30677"
+msgid "A minute ago"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Recently"
+msgstr ""
+
+msgctxt "#30679"
+msgid "An hour ago"
+msgstr ""
+
+msgctxt "#30680"
+msgid "Two hours ago"
+msgstr ""
+
+msgctxt "#30681"
+msgid "Three hours ago"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Yesterday at"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Two days ago"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Today at"
 msgstr ""

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -862,7 +862,7 @@ msgctxt "#30648"
 msgid "API Key is incorrect. Settings - API - API Key"
 msgstr ""
 
-msgctxt "#30649
+msgctxt "#30649"
 msgid "Client Id is incorrect. Settings - API - API Id"
 msgstr ""
 
@@ -968,4 +968,40 @@ msgstr ""
 
 msgctxt "#30675"
 msgid "Use playback history (watched, resume tracking)"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Just now"
+msgstr ""
+
+msgctxt "#30677"
+msgid "A minute ago"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Recently"
+msgstr ""
+
+msgctxt "#30679"
+msgid "An hour ago"
+msgstr ""
+
+msgctxt "#30680"
+msgid "Two hours ago"
+msgstr ""
+
+msgctxt "#30681"
+msgid "Three hours ago"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Yesterday at"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Two days ago"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Today at"
 msgstr ""

--- a/resources/language/resource.language.ko_kr/strings.po
+++ b/resources/language/resource.language.ko_kr/strings.po
@@ -862,7 +862,7 @@ msgctxt "#30648"
 msgid "API Key is incorrect. Settings - API - API Key"
 msgstr ""
 
-msgctxt "#30649
+msgctxt "#30649"
 msgid "Client Id is incorrect. Settings - API - API Id"
 msgstr ""
 
@@ -968,4 +968,40 @@ msgstr ""
 
 msgctxt "#30675"
 msgid "Use playback history (watched, resume tracking)"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Just now"
+msgstr ""
+
+msgctxt "#30677"
+msgid "A minute ago"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Recently"
+msgstr ""
+
+msgctxt "#30679"
+msgid "An hour ago"
+msgstr ""
+
+msgctxt "#30680"
+msgid "Two hours ago"
+msgstr ""
+
+msgctxt "#30681"
+msgid "Three hours ago"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Yesterday at"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Two days ago"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Today at"
 msgstr ""

--- a/resources/language/resource.language.nb_no/strings.po
+++ b/resources/language/resource.language.nb_no/strings.po
@@ -879,7 +879,7 @@ msgctxt "#30648"
 msgid "API Key is incorrect. Settings - API - API Key"
 msgstr ""
 
-msgctxt "#30649
+msgctxt "#30649"
 msgid "Client Id is incorrect. Settings - API - API Id"
 msgstr ""
 
@@ -985,4 +985,40 @@ msgstr ""
 
 msgctxt "#30675"
 msgid "Use playback history (watched, resume tracking)"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Just now"
+msgstr ""
+
+msgctxt "#30677"
+msgid "A minute ago"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Recently"
+msgstr ""
+
+msgctxt "#30679"
+msgid "An hour ago"
+msgstr ""
+
+msgctxt "#30680"
+msgid "Two hours ago"
+msgstr ""
+
+msgctxt "#30681"
+msgid "Three hours ago"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Yesterday at"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Two days ago"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Today at"
 msgstr ""

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -871,7 +871,7 @@ msgctxt "#30648"
 msgid "API Key is incorrect. Settings - API - API Key"
 msgstr ""
 
-msgctxt "#30649
+msgctxt "#30649"
 msgid "Client Id is incorrect. Settings - API - API Id"
 msgstr ""
 
@@ -977,4 +977,40 @@ msgstr ""
 
 msgctxt "#30675"
 msgid "Use playback history (watched, resume tracking)"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Just now"
+msgstr ""
+
+msgctxt "#30677"
+msgid "A minute ago"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Recently"
+msgstr ""
+
+msgctxt "#30679"
+msgid "An hour ago"
+msgstr ""
+
+msgctxt "#30680"
+msgid "Two hours ago"
+msgstr ""
+
+msgctxt "#30681"
+msgid "Three hours ago"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Yesterday at"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Two days ago"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Today at"
 msgstr ""

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -861,7 +861,7 @@ msgctxt "#30648"
 msgid "API Key is incorrect. Settings - API - API Key"
 msgstr ""
 
-msgctxt "#30649
+msgctxt "#30649"
 msgid "Client Id is incorrect. Settings - API - API Id"
 msgstr ""
 
@@ -967,4 +967,40 @@ msgstr ""
 
 msgctxt "#30675"
 msgid "Use playback history (watched, resume tracking)"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Just now"
+msgstr ""
+
+msgctxt "#30677"
+msgid "A minute ago"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Recently"
+msgstr ""
+
+msgctxt "#30679"
+msgid "An hour ago"
+msgstr ""
+
+msgctxt "#30680"
+msgid "Two hours ago"
+msgstr ""
+
+msgctxt "#30681"
+msgid "Three hours ago"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Yesterday at"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Two days ago"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Today at"
 msgstr ""

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -860,7 +860,7 @@ msgctxt "#30648"
 msgid "API Key is incorrect. Settings - API - API Key"
 msgstr ""
 
-msgctxt "#30649
+msgctxt "#30649"
 msgid "Client Id is incorrect. Settings - API - API Id"
 msgstr ""
 
@@ -966,4 +966,40 @@ msgstr ""
 
 msgctxt "#30675"
 msgid "Use playback history (watched, resume tracking)"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Just now"
+msgstr ""
+
+msgctxt "#30677"
+msgid "A minute ago"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Recently"
+msgstr ""
+
+msgctxt "#30679"
+msgid "An hour ago"
+msgstr ""
+
+msgctxt "#30680"
+msgid "Two hours ago"
+msgstr ""
+
+msgctxt "#30681"
+msgid "Three hours ago"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Yesterday at"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Two days ago"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Today at"
 msgstr ""

--- a/resources/language/resource.language.pt_pt/strings.po
+++ b/resources/language/resource.language.pt_pt/strings.po
@@ -862,7 +862,7 @@ msgctxt "#30648"
 msgid "API Key is incorrect. Settings - API - API Key"
 msgstr ""
 
-msgctxt "#30649
+msgctxt "#30649"
 msgid "Client Id is incorrect. Settings - API - API Id"
 msgstr ""
 
@@ -968,4 +968,40 @@ msgstr ""
 
 msgctxt "#30675"
 msgid "Use playback history (watched, resume tracking)"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Just now"
+msgstr ""
+
+msgctxt "#30677"
+msgid "A minute ago"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Recently"
+msgstr ""
+
+msgctxt "#30679"
+msgid "An hour ago"
+msgstr ""
+
+msgctxt "#30680"
+msgid "Two hours ago"
+msgstr ""
+
+msgctxt "#30681"
+msgid "Three hours ago"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Yesterday at"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Two days ago"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Today at"
 msgstr ""

--- a/resources/language/resource.language.ro_ro/strings.po
+++ b/resources/language/resource.language.ro_ro/strings.po
@@ -862,7 +862,7 @@ msgctxt "#30648"
 msgid "API Key is incorrect. Settings - API - API Key"
 msgstr ""
 
-msgctxt "#30649
+msgctxt "#30649"
 msgid "Client Id is incorrect. Settings - API - API Id"
 msgstr ""
 
@@ -968,4 +968,40 @@ msgstr ""
 
 msgctxt "#30675"
 msgid "Use playback history (watched, resume tracking)"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Just now"
+msgstr ""
+
+msgctxt "#30677"
+msgid "A minute ago"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Recently"
+msgstr ""
+
+msgctxt "#30679"
+msgid "An hour ago"
+msgstr ""
+
+msgctxt "#30680"
+msgid "Two hours ago"
+msgstr ""
+
+msgctxt "#30681"
+msgid "Three hours ago"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Yesterday at"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Two days ago"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Today at"
 msgstr ""

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -871,7 +871,7 @@ msgctxt "#30648"
 msgid "API Key is incorrect. Settings - API - API Key"
 msgstr ""
 
-msgctxt "#30649
+msgctxt "#30649"
 msgid "Client Id is incorrect. Settings - API - API Id"
 msgstr ""
 
@@ -977,4 +977,40 @@ msgstr ""
 
 msgctxt "#30675"
 msgid "Use playback history (watched, resume tracking)"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Just now"
+msgstr ""
+
+msgctxt "#30677"
+msgid "A minute ago"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Recently"
+msgstr ""
+
+msgctxt "#30679"
+msgid "An hour ago"
+msgstr ""
+
+msgctxt "#30680"
+msgid "Two hours ago"
+msgstr ""
+
+msgctxt "#30681"
+msgid "Three hours ago"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Yesterday at"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Two days ago"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Today at"
 msgstr ""

--- a/resources/language/resource.language.sk_sk/strings.po
+++ b/resources/language/resource.language.sk_sk/strings.po
@@ -862,7 +862,7 @@ msgctxt "#30648"
 msgid "API Key is incorrect. Settings - API - API Key"
 msgstr ""
 
-msgctxt "#30649
+msgctxt "#30649"
 msgid "Client Id is incorrect. Settings - API - API Id"
 msgstr ""
 
@@ -968,4 +968,40 @@ msgstr ""
 
 msgctxt "#30675"
 msgid "Use playback history (watched, resume tracking)"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Just now"
+msgstr ""
+
+msgctxt "#30677"
+msgid "A minute ago"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Recently"
+msgstr ""
+
+msgctxt "#30679"
+msgid "An hour ago"
+msgstr ""
+
+msgctxt "#30680"
+msgid "Two hours ago"
+msgstr ""
+
+msgctxt "#30681"
+msgid "Three hours ago"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Yesterday at"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Two days ago"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Today at"
 msgstr ""

--- a/resources/language/resource.language.uk_ua/strings.po
+++ b/resources/language/resource.language.uk_ua/strings.po
@@ -862,7 +862,7 @@ msgctxt "#30648"
 msgid "API Key is incorrect. Settings - API - API Key"
 msgstr ""
 
-msgctxt "#30649
+msgctxt "#30649"
 msgid "Client Id is incorrect. Settings - API - API Id"
 msgstr ""
 
@@ -968,4 +968,40 @@ msgstr ""
 
 msgctxt "#30675"
 msgid "Use playback history (watched, resume tracking)"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Just now"
+msgstr ""
+
+msgctxt "#30677"
+msgid "A minute ago"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Recently"
+msgstr ""
+
+msgctxt "#30679"
+msgid "An hour ago"
+msgstr ""
+
+msgctxt "#30680"
+msgid "Two hours ago"
+msgstr ""
+
+msgctxt "#30681"
+msgid "Three hours ago"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Yesterday at"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Two days ago"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Today at"
 msgstr ""

--- a/resources/language/resource.language.zh_cn/strings.po
+++ b/resources/language/resource.language.zh_cn/strings.po
@@ -344,7 +344,7 @@ msgstr "請使用瀏覽器開啟下列連結： '%s'"
 
 msgctxt "#30519"
 msgid "and enter the following code:"
-msgstr ""然後輸入認證碼："
+msgstr "然後輸入認證碼："
 
 msgctxt "#30520"
 msgid "Add to..."
@@ -862,7 +862,7 @@ msgctxt "#30648"
 msgid "API Key is incorrect. Settings - API - API Key"
 msgstr ""
 
-msgctxt "#30649
+msgctxt "#30649"
 msgid "Client Id is incorrect. Settings - API - API Id"
 msgstr ""
 
@@ -968,4 +968,40 @@ msgstr ""
 
 msgctxt "#30675"
 msgid "Use playback history (watched, resume tracking)"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Just now"
+msgstr ""
+
+msgctxt "#30677"
+msgid "A minute ago"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Recently"
+msgstr ""
+
+msgctxt "#30679"
+msgid "An hour ago"
+msgstr ""
+
+msgctxt "#30680"
+msgid "Two hours ago"
+msgstr ""
+
+msgctxt "#30681"
+msgid "Three hours ago"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Yesterday at"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Two days ago"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Today at"
 msgstr ""

--- a/resources/lib/youtube_plugin/kodion/impl/xbmc/xbmc_items.py
+++ b/resources/lib/youtube_plugin/kodion/impl/xbmc/xbmc_items.py
@@ -110,8 +110,7 @@ def to_video_item(context, video_item):
         local_dt = utils.datetime_parser.utc_to_local(publishedAt)
         item.setProperty(u'PublishedSince',
                          utils.to_unicode(utils.datetime_parser.datetime_to_since(local_dt, context)))
-        item.setProperty(u'PublishedLocal',
-                         utils.to_unicode(unicode(local_dt)))
+        item.setProperty(u'PublishedLocal', str(local_dt))
 
     _info_labels = info_labels.create_from_item(context, video_item)
 

--- a/resources/lib/youtube_plugin/kodion/impl/xbmc/xbmc_items.py
+++ b/resources/lib/youtube_plugin/kodion/impl/xbmc/xbmc_items.py
@@ -108,8 +108,8 @@ def to_video_item(context, video_item):
     publishedAt = video_item.get_aired_utc()
     if publishedAt:
         local_dt = item_utils.utc_to_local(publishedAt)
-        item.setProperty(u"PublishedSince", unicode(item_utils.datetime_to_since(local_dt, context)))
-        item.setProperty(u"PublishedLocal", unicode(local_dt))
+        item.setProperty(u'PublishedSince', unicode(item_utils.datetime_to_since(local_dt, context)))
+        item.setProperty(u'PublishedLocal', unicode(local_dt))
 
     _info_labels = info_labels.create_from_item(context, video_item)
 

--- a/resources/lib/youtube_plugin/kodion/impl/xbmc/xbmc_items.py
+++ b/resources/lib/youtube_plugin/kodion/impl/xbmc/xbmc_items.py
@@ -7,6 +7,7 @@ import xbmcgui
 from ...items import VideoItem, AudioItem, UriItem
 from ... import utils
 from . import info_labels
+from ...items import utils as item_utils
 
 
 def to_play_item(context, play_item):
@@ -103,6 +104,12 @@ def to_video_item(context, video_item):
         item.addContextMenuItems(video_item.get_context_menu(), replaceItems=video_item.replace_context_menu())
 
     item.setProperty(u'IsPlayable', u'true')
+
+    publishedAt = video_item.get_aired_utc()
+    if publishedAt:
+        local_dt = item_utils.utc_to_local(publishedAt)
+        item.setProperty(u"PublishedSince", unicode(item_utils.datetime_to_since(local_dt, context)))
+        item.setProperty(u"PublishedLocal", unicode(local_dt))
 
     _info_labels = info_labels.create_from_item(context, video_item)
 

--- a/resources/lib/youtube_plugin/kodion/impl/xbmc/xbmc_items.py
+++ b/resources/lib/youtube_plugin/kodion/impl/xbmc/xbmc_items.py
@@ -107,9 +107,11 @@ def to_video_item(context, video_item):
 
     publishedAt = video_item.get_aired_utc()
     if publishedAt:
-        local_dt = item_utils.utc_to_local(publishedAt)
-        item.setProperty(u'PublishedSince', unicode(item_utils.datetime_to_since(local_dt, context)))
-        item.setProperty(u'PublishedLocal', unicode(local_dt))
+        local_dt = utils.datetime_parser.utc_to_local(publishedAt)
+        item.setProperty(u'PublishedSince',
+                         utils.to_unicode(utils.datetime_parser.datetime_to_since(local_dt, context)))
+        item.setProperty(u'PublishedLocal',
+                         utils.to_unicode(unicode(local_dt)))
 
     _info_labels = info_labels.create_from_item(context, video_item)
 

--- a/resources/lib/youtube_plugin/kodion/items/utils.py
+++ b/resources/lib/youtube_plugin/kodion/items/utils.py
@@ -1,8 +1,11 @@
+# coding=utf-8
 __author__ = 'bromix'
 
 from six import string_types
 
 import json
+import datetime
+import time
 
 from .video_item import VideoItem
 from .directory_item import DirectoryItem
@@ -72,3 +75,41 @@ def to_json(base_item):
         return obj.__dict__
 
     return _to_json(base_item)
+
+
+def utc_to_local(dt):
+    now = time.time()
+    offset = datetime.datetime.fromtimestamp(now) - datetime.datetime.utcfromtimestamp(now)
+    return dt + offset
+
+
+def datetime_to_since(dt, context):
+    now = datetime.datetime.now()
+    diff = now - dt
+    yesterday = now - datetime.timedelta(days=1)
+    yyesterday = now - datetime.timedelta(days=2)
+    use_yesterday = (now - yesterday).total_seconds() > 10800
+    seconds = diff.total_seconds()
+
+    if seconds > 0:
+        if seconds < 60:
+            return context.localize("30676")
+        elif 60 <= seconds < 120:
+            return context.localize("30677")
+        elif 120 <= seconds < 3600:
+            return context.localize("30678")
+        elif 3600 <= seconds < 7200:
+            return context.localize("30679")
+        elif 7200 <= seconds < 10800:
+            return context.localize("30680")
+        elif 10800 <= seconds < 14400:
+            return context.localize("30681")
+        elif use_yesterday and dt.date() == yesterday.date():
+            return u" ".join([context.localize("30682"), context.format_time(dt)])
+        elif dt.date() == yyesterday.date():
+            return context.localize("30683")
+        elif 5400 <= seconds < 86400:
+            return u" ".join([context.localize("30684"), context.format_time(dt)])
+        elif 86400 <= seconds < 172800:
+            return u" ".join([context.localize("30682"), context.format_time(dt)])
+    return " ".join([context.format_date_short(dt), context.format_time(dt)])

--- a/resources/lib/youtube_plugin/kodion/items/utils.py
+++ b/resources/lib/youtube_plugin/kodion/items/utils.py
@@ -4,8 +4,6 @@ __author__ = 'bromix'
 from six import string_types
 
 import json
-import datetime
-import time
 
 from .video_item import VideoItem
 from .directory_item import DirectoryItem
@@ -75,41 +73,3 @@ def to_json(base_item):
         return obj.__dict__
 
     return _to_json(base_item)
-
-
-def utc_to_local(dt):
-    now = time.time()
-    offset = datetime.datetime.fromtimestamp(now) - datetime.datetime.utcfromtimestamp(now)
-    return dt + offset
-
-
-def datetime_to_since(dt, context):
-    now = datetime.datetime.now()
-    diff = now - dt
-    yesterday = now - datetime.timedelta(days=1)
-    yyesterday = now - datetime.timedelta(days=2)
-    use_yesterday = (now - yesterday).total_seconds() > 10800
-    seconds = diff.total_seconds()
-
-    if seconds > 0:
-        if seconds < 60:
-            return context.localize('30676')
-        elif 60 <= seconds < 120:
-            return context.localize('30677')
-        elif 120 <= seconds < 3600:
-            return context.localize('30678')
-        elif 3600 <= seconds < 7200:
-            return context.localize('30679')
-        elif 7200 <= seconds < 10800:
-            return context.localize('30680')
-        elif 10800 <= seconds < 14400:
-            return context.localize('30681')
-        elif use_yesterday and dt.date() == yesterday.date():
-            return u' '.join([context.localize('30682'), context.format_time(dt)])
-        elif dt.date() == yyesterday.date():
-            return context.localize('30683')
-        elif 5400 <= seconds < 86400:
-            return u' '.join([context.localize('30684'), context.format_time(dt)])
-        elif 86400 <= seconds < 172800:
-            return u' '.join([context.localize('30682'), context.format_time(dt)])
-    return u' '.join([context.format_date_short(dt), context.format_time(dt)])

--- a/resources/lib/youtube_plugin/kodion/items/utils.py
+++ b/resources/lib/youtube_plugin/kodion/items/utils.py
@@ -93,23 +93,23 @@ def datetime_to_since(dt, context):
 
     if seconds > 0:
         if seconds < 60:
-            return context.localize("30676")
+            return context.localize('30676')
         elif 60 <= seconds < 120:
-            return context.localize("30677")
+            return context.localize('30677')
         elif 120 <= seconds < 3600:
-            return context.localize("30678")
+            return context.localize('30678')
         elif 3600 <= seconds < 7200:
-            return context.localize("30679")
+            return context.localize('30679')
         elif 7200 <= seconds < 10800:
-            return context.localize("30680")
+            return context.localize('30680')
         elif 10800 <= seconds < 14400:
-            return context.localize("30681")
+            return context.localize('30681')
         elif use_yesterday and dt.date() == yesterday.date():
-            return u" ".join([context.localize("30682"), context.format_time(dt)])
+            return u' '.join([context.localize('30682'), context.format_time(dt)])
         elif dt.date() == yyesterday.date():
-            return context.localize("30683")
+            return context.localize('30683')
         elif 5400 <= seconds < 86400:
-            return u" ".join([context.localize("30684"), context.format_time(dt)])
+            return u' '.join([context.localize('30684'), context.format_time(dt)])
         elif 86400 <= seconds < 172800:
-            return u" ".join([context.localize("30682"), context.format_time(dt)])
-    return " ".join([context.format_date_short(dt), context.format_time(dt)])
+            return u' '.join([context.localize('30682'), context.format_time(dt)])
+    return u' '.join([context.format_date_short(dt), context.format_time(dt)])

--- a/resources/lib/youtube_plugin/kodion/items/video_item.py
+++ b/resources/lib/youtube_plugin/kodion/items/video_item.py
@@ -11,6 +11,7 @@ class VideoItem(BaseItem):
         BaseItem.__init__(self, name, uri, image, fanart)
         self._genre = None
         self._aired = None
+        self._aired_utc = None
         self._duration = None
         self._director = None
         self._premiered = None
@@ -153,6 +154,12 @@ class VideoItem(BaseItem):
     def set_aired(self, year, month, day):
         date = datetime.date(year, month, day)
         self._aired = date.isoformat()
+
+    def set_aired_utc(self, dt):
+        self._aired_utc = dt
+
+    def get_aired_utc(self):
+        return self._aired_utc
 
     def set_aired_from_datetime(self, date_time):
         self.set_aired(year=date_time.year, month=date_time.month, day=date_time.day)

--- a/resources/lib/youtube_plugin/youtube/helper/utils.py
+++ b/resources/lib/youtube_plugin/youtube/helper/utils.py
@@ -3,6 +3,7 @@ from six import PY2
 
 import re
 import time
+import datetime as dt
 
 from ... import kodion
 from ...kodion import utils
@@ -260,6 +261,12 @@ def update_video_infos(provider, context, video_id_dict, playlist_item_id_dict=N
         # date time
         if not datetime and 'publishedAt' in snippet:
             datetime = utils.datetime_parser.parse(snippet['publishedAt'])
+            try:
+                parsed_dt = dt.datetime.strptime(snippet['publishedAt'], "%Y-%m-%dT%H:%M:%S.%fZ")
+            except TypeError:
+                # see https://forum.kodi.tv/showthread.php?tid=112916
+                parsed_dt = dt.datetime(*time.strptime(snippet['publishedAt'], "%Y-%m-%dT%H:%M:%S.%fZ")[:6])
+            video_item.set_aired_utc(parsed_dt)
 
         if datetime:
             video_item.set_year_from_datetime(datetime)

--- a/resources/lib/youtube_plugin/youtube/helper/utils.py
+++ b/resources/lib/youtube_plugin/youtube/helper/utils.py
@@ -3,7 +3,6 @@ from six import PY2
 
 import re
 import time
-import datetime as dt
 
 from ... import kodion
 from ...kodion import utils
@@ -261,12 +260,7 @@ def update_video_infos(provider, context, video_id_dict, playlist_item_id_dict=N
         # date time
         if not datetime and 'publishedAt' in snippet:
             datetime = utils.datetime_parser.parse(snippet['publishedAt'])
-            try:
-                parsed_dt = dt.datetime.strptime(snippet['publishedAt'], "%Y-%m-%dT%H:%M:%S.%fZ")
-            except TypeError:
-                # see https://forum.kodi.tv/showthread.php?tid=112916
-                parsed_dt = dt.datetime(*time.strptime(snippet['publishedAt'], "%Y-%m-%dT%H:%M:%S.%fZ")[:6])
-            video_item.set_aired_utc(parsed_dt)
+            video_item.set_aired_utc(utils.datetime_parser.strptime(snippet['publishedAt']))
 
         if datetime:
             video_item.set_year_from_datetime(datetime)


### PR DESCRIPTION
This PR is in reference to #329 and somewhat a proof-of-concept. 
- fixes a couple of issues inside the translation files
- adds item properties `PublishedSince` (dynamic localized short description for publishedAt) and `PublishedLocal` (the full datetime object), both adjusted to the local timezone

`PublishedSince` can be:
- Just now
- A minute ago
- Recently
- An hour ago
- Two hours ago
- Three hours ago
- Yesterday at TIME
- Two days ago
- Today at TIME
- The date and time of the publication

All of those strings are localized.