### PR TITLE
Remove duplicate hour instance from kodi time format

### DIFF
--- a/resources/lib/youtube_plugin/kodion/impl/xbmc/xbmc_context.py
+++ b/resources/lib/youtube_plugin/kodion/impl/xbmc/xbmc_context.py
@@ -88,7 +88,7 @@ class XbmcContext(AbstractContext):
         if isinstance(_time_obj, datetime.time):
             _time_obj = datetime.time(_time_obj.hour, _time_obj.minute, _time_obj.second)
 
-        return _time_obj.strftime(time_format)
+        return _time_obj.strftime(time_format.replace("%H%H", "%H"))
 
     def get_language(self):
         """


### PR DESCRIPTION
When set to the time format `HH:mm:ss`, the resulting time format from `xbmc.getRegion` becomes `%H%H:%M:%S`.

This seems like a Kodi bug, this PR circumvents that.