### PR TITLE
Add button to play single video with subtitles

### DIFF
--- a/resources/language/resource.language.bg_bg/strings.po
+++ b/resources/language/resource.language.bg_bg/strings.po
@@ -1073,3 +1073,7 @@ msgstr ""
 msgctxt "#30701"
 msgid "Failed to obtain client IP"
 msgstr ""
+
+msgctxt "#30702"
+msgid "Play with subtitles"
+msgstr ""

--- a/resources/language/resource.language.cs_cz/strings.po
+++ b/resources/language/resource.language.cs_cz/strings.po
@@ -1077,3 +1077,7 @@ msgstr ""
 msgctxt "#30701"
 msgid "Failed to obtain client IP"
 msgstr ""
+
+msgctxt "#30702"
+msgid "Play with subtitles"
+msgstr ""

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -1073,3 +1073,7 @@ msgstr ""
 msgctxt "#30701"
 msgid "Failed to obtain client IP"
 msgstr ""
+
+msgctxt "#30702"
+msgid "Play with subtitles"
+msgstr ""

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -1089,3 +1089,7 @@ msgstr "Η διεύθυνση πελάτη είναι %s"
 msgctxt "#30701"
 msgid "Failed to obtain client IP"
 msgstr "Αποτυχία λήψης διεύθυνσης IP πελάτη"
+
+msgctxt "#30702"
+msgid "Play with subtitles"
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1090,3 +1090,7 @@ msgstr ""
 msgctxt "#30701"
 msgid "Failed to obtain client IP"
 msgstr ""
+
+msgctxt "#30702"
+msgid "Play with subtitles"
+msgstr ""

--- a/resources/language/resource.language.en_us/strings.po
+++ b/resources/language/resource.language.en_us/strings.po
@@ -1091,3 +1091,7 @@ msgstr ""
 msgctxt "#30701"
 msgid "Failed to obtain client IP"
 msgstr ""
+
+msgctxt "#30702"
+msgid "Play with subtitles"
+msgstr ""

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -1090,3 +1090,7 @@ msgstr "La IP del cliente es %s"
 msgctxt "#30701"
 msgid "Failed to obtain client IP"
 msgstr "No se pudo obtener la IP de cliente"
+
+msgctxt "#30702"
+msgid "Play with subtitles"
+msgstr ""

--- a/resources/language/resource.language.fi_fi/strings.po
+++ b/resources/language/resource.language.fi_fi/strings.po
@@ -1075,3 +1075,7 @@ msgstr ""
 msgctxt "#30701"
 msgid "Failed to obtain client IP"
 msgstr ""
+
+msgctxt "#30702"
+msgid "Play with subtitles"
+msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -1075,3 +1075,7 @@ msgstr ""
 msgctxt "#30701"
 msgid "Failed to obtain client IP"
 msgstr ""
+
+msgctxt "#30702"
+msgid "Play with subtitles"
+msgstr ""

--- a/resources/language/resource.language.he_il/strings.po
+++ b/resources/language/resource.language.he_il/strings.po
@@ -1084,3 +1084,7 @@ msgstr ""
 msgctxt "#30701"
 msgid "Failed to obtain client IP"
 msgstr ""
+
+msgctxt "#30702"
+msgid "Play with subtitles"
+msgstr ""

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -1072,3 +1072,7 @@ msgstr ""
 msgctxt "#30701"
 msgid "Failed to obtain client IP"
 msgstr ""
+
+msgctxt "#30702"
+msgid "Play with subtitles"
+msgstr ""

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -1073,3 +1073,7 @@ msgstr ""
 msgctxt "#30701"
 msgid "Failed to obtain client IP"
 msgstr ""
+
+msgctxt "#30702"
+msgid "Play with subtitles"
+msgstr ""

--- a/resources/language/resource.language.ko_kr/strings.po
+++ b/resources/language/resource.language.ko_kr/strings.po
@@ -1073,3 +1073,7 @@ msgstr ""
 msgctxt "#30701"
 msgid "Failed to obtain client IP"
 msgstr ""
+
+msgctxt "#30702"
+msgid "Play with subtitles"
+msgstr ""

--- a/resources/language/resource.language.nb_no/strings.po
+++ b/resources/language/resource.language.nb_no/strings.po
@@ -1090,3 +1090,7 @@ msgstr ""
 msgctxt "#30701"
 msgid "Failed to obtain client IP"
 msgstr ""
+
+msgctxt "#30702"
+msgid "Play with subtitles"
+msgstr ""

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -1082,3 +1082,7 @@ msgstr ""
 msgctxt "#30701"
 msgid "Failed to obtain client IP"
 msgstr "Verkrijgen client IP mislukt"
+
+msgctxt "#30702"
+msgid "Play with subtitles"
+msgstr ""

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -1072,3 +1072,7 @@ msgstr ""
 msgctxt "#30701"
 msgid "Failed to obtain client IP"
 msgstr ""
+
+msgctxt "#30702"
+msgid "Play with subtitles"
+msgstr ""

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -1071,3 +1071,7 @@ msgstr ""
 msgctxt "#30701"
 msgid "Failed to obtain client IP"
 msgstr ""
+
+msgctxt "#30702"
+msgid "Play with subtitles"
+msgstr ""

--- a/resources/language/resource.language.pt_pt/strings.po
+++ b/resources/language/resource.language.pt_pt/strings.po
@@ -1073,3 +1073,7 @@ msgstr ""
 msgctxt "#30701"
 msgid "Failed to obtain client IP"
 msgstr ""
+
+msgctxt "#30702"
+msgid "Play with subtitles"
+msgstr ""

--- a/resources/language/resource.language.ro_ro/strings.po
+++ b/resources/language/resource.language.ro_ro/strings.po
@@ -1073,3 +1073,7 @@ msgstr ""
 msgctxt "#30701"
 msgid "Failed to obtain client IP"
 msgstr ""
+
+msgctxt "#30702"
+msgid "Play with subtitles"
+msgstr ""

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -1082,3 +1082,7 @@ msgstr ""
 msgctxt "#30701"
 msgid "Failed to obtain client IP"
 msgstr ""
+
+msgctxt "#30702"
+msgid "Play with subtitles"
+msgstr ""

--- a/resources/language/resource.language.sk_sk/strings.po
+++ b/resources/language/resource.language.sk_sk/strings.po
@@ -1073,3 +1073,7 @@ msgstr ""
 msgctxt "#30701"
 msgid "Failed to obtain client IP"
 msgstr ""
+
+msgctxt "#30702"
+msgid "Play with subtitles"
+msgstr ""

--- a/resources/language/resource.language.uk_ua/strings.po
+++ b/resources/language/resource.language.uk_ua/strings.po
@@ -1073,3 +1073,7 @@ msgstr ""
 msgctxt "#30701"
 msgid "Failed to obtain client IP"
 msgstr ""
+
+msgctxt "#30702"
+msgid "Play with subtitles"
+msgstr ""

--- a/resources/language/resource.language.zh_cn/strings.po
+++ b/resources/language/resource.language.zh_cn/strings.po
@@ -1073,3 +1073,7 @@ msgstr ""
 msgctxt "#30701"
 msgid "Failed to obtain client IP"
 msgstr ""
+
+msgctxt "#30702"
+msgid "Play with subtitles"
+msgstr ""

--- a/resources/lib/youtube_plugin/youtube/helper/subtitles.py
+++ b/resources/lib/youtube_plugin/youtube/helper/subtitles.py
@@ -85,7 +85,11 @@ class Subtitles(object):
         return text
 
     def get_subtitles(self):
-        languages = self.context.get_settings().subtitle_languages()
+        prompt_for_subtitles = self.context.get_param('prompt_for_subtitles')
+        if prompt_for_subtitles:
+            languages = self.LANG_PROMPT
+        else:
+            languages = self.context.get_settings().subtitle_languages()
         self.context.log_debug('Subtitle get_subtitles: for setting |%s|' % str(languages))
         if languages == self.LANG_NONE:
             return []

--- a/resources/lib/youtube_plugin/youtube/helper/utils.py
+++ b/resources/lib/youtube_plugin/youtube/helper/utils.py
@@ -376,6 +376,9 @@ def update_video_infos(provider, context, video_id_dict, playlist_item_id_dict=N
                                               is_logged_in=provider.is_logged_in(),
                                               refresh_container=refresh_container)
 
+        if not video_item.live:
+            yt_context_menu.append_play_with_subtitles(context_menu, provider, context, video_id)
+
         if len(context_menu) > 0:
             video_item.set_context_menu(context_menu, replace=replace_context_menu)
 

--- a/resources/lib/youtube_plugin/youtube/helper/yt_context_menu.py
+++ b/resources/lib/youtube_plugin/youtube/helper/yt_context_menu.py
@@ -187,3 +187,9 @@ def append_reset_resume_point(context_menu, provider, context, video_id):
                          'RunPlugin(%s)' % context.create_uri(['playback_history'],
                                                               {'video_id': video_id,
                                                                'action': 'reset_resume'})))
+
+def append_play_with_subtitles(context_menu, provider, context, video_id):
+    context_menu.append((context.localize(provider.LOCAL_MAP['youtube.video.play_with_subtitles']),
+                         'PlayMedia(%s)' % context.create_uri(['play'],
+                                                              {'video_id': video_id,
+                                                               'prompt_for_subtitles': True})))

--- a/resources/lib/youtube_plugin/youtube/provider.py
+++ b/resources/lib/youtube_plugin/youtube/provider.py
@@ -141,7 +141,8 @@ class Provider(kodion.AbstractProvider):
                  'youtube.data.cache': 30687,
                  'youtube.httpd.not.running': 30699,
                  'youtube.client.ip': 30700,
-                 'youtube.client.ip.failed': 30701
+                 'youtube.client.ip.failed': 30701,
+                 'youtube.video.play_with_subtitles': 30702
                  }
 
     def __init__(self):


### PR DESCRIPTION
Adds a button called "Play with subtitles" to video items (except for live videos where it seems subtitles are not supported yet?) to be able to override the current subtitle setting and always prompt for subtitles. The use case for this is that I, personally, always have subtitles off but for certain channels (read primitive technology) want to turn it on.

I'm not really sure if reading parameters in subtitles.py is the best way in terms of implementation but it seemed to be the simplest way to do it.