### PR TITLE
mpeg-dash discard video streams using av1 codec

### DIFF
--- a/resources/lib/youtube_plugin/kodion/impl/xbmc/xbmc_context.py
+++ b/resources/lib/youtube_plugin/kodion/impl/xbmc/xbmc_context.py
@@ -282,6 +282,7 @@ class XbmcContext(AbstractContext):
             'vp9.2': None,
             'vorbis': None,
             'opus': None,
+            'av1': None,
         }
 
         if capability is None:

--- a/resources/lib/youtube_plugin/youtube/helper/video_info.py
+++ b/resources/lib/youtube_plugin/youtube/helper/video_info.py
@@ -1109,6 +1109,9 @@ class VideoInfo(object):
                         elif 'vp9' == video_codec.lower() and 'vp9' not in ia_capabilities:
                             discarded_streams.append(get_discarded_video(mime, i, data[mime][i]))
                             continue
+                        elif video_codec.lower().startswith(('av01', 'av1')) and 'av1' not in ia_capabilities:
+                            discarded_streams.append(get_discarded_video(mime, i, data[mime][i]))
+                            continue
 
                         has_video_stream = True
                         if int(data[mime][i]['bandwidth']) > int(stream_info['video']['bandwidth']):


### PR DESCRIPTION
- currently not supported by InputStream Adaptive