### PR TITLE
HTTP server: Fix /client_ip when using Python 3

### DIFF
--- a/resources/lib/youtube_plugin/kodion/utils/http_server.py
+++ b/resources/lib/youtube_plugin/kodion/utils/http_server.py
@@ -67,7 +67,7 @@ class YouTubeRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             self.send_header('Content-Type', 'application/json; charset=utf-8')
             self.send_header('Content-Length', len(client_json))
             self.end_headers()
-            self.wfile.write(client_json)
+            self.wfile.write(client_json.encode("utf-8"))
 
         logger.log_debug('HTTPServer: Request uri path |{proxy_path}|'.format(proxy_path=self.path))
 


### PR DESCRIPTION
Fixes the following error on Kodi master using Python 3.6:
```
Exception happened during processing of request from
('127.0.0.1', 62594)
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/socketserver.py", line 320, in _handle_request_noblock self.process_request(request, client_address)
  File "/usr/local/lib/python3.6/socketserver.py", line 351, in process_request self.finish_request(request, client_address)
  File "/usr/local/lib/python3.6/socketserver.py", line 364, in finish_request self.RequestHandlerClass(request, client_address, self)
  File "/home/tobias/.kodi/addons/plugin.video.youtube/resources/lib/youtube_plugin/kodion/utils/http_server.py", line 41, in __init__ BaseHTTPServer.BaseHTTPRequestHandler.__init__(self, request, client_address, server)
  File "/usr/local/lib/python3.6/socketserver.py", line 724, in __init__ self.handle()
  File "/usr/local/lib/python3.6/http/server.py", line 418, in handle self.handle_one_request()
  File "/usr/local/lib/python3.6/http/server.py", line 406, in handle_one_request method()
  File "/home/tobias/.kodi/addons/plugin.video.youtube/resources/lib/youtube_plugin/kodion/utils/http_server.py", line 70, in do_GET self.wfile.write(client_json)
  File "/usr/local/lib/python3.6/socketserver.py", line 803, in write self._sock.sendall(b)
TypeError: a bytes-like object is required, not 'str'
```