### PR TITLE
Signal endofdirectory in case of a provider navigation exception

### DIFF
--- a/resources/lib/youtube_plugin/kodion/impl/xbmc/xbmc_runner.py
+++ b/resources/lib/youtube_plugin/kodion/impl/xbmc/xbmc_runner.py
@@ -27,15 +27,17 @@ class XbmcRunner(AbstractProviderRunner):
 
     def run(self, provider, context=None):
 
+        self.handle = context.get_handle()
+
         try:
             results = provider.navigate(context)
         except KodionException as ex:
             if provider.handle_exception(context, ex):
                 context.log_error(ex.__str__())
                 xbmcgui.Dialog().ok("Exception in ContentProvider", ex.__str__())
+            xbmcplugin.endOfDirectory(self.handle, succeeded=False)
             return
 
-        self.handle = context.get_handle()
         self.settings = context.get_settings()
 
         result = results[0]


### PR DESCRIPTION
Hey,

Found this problem due to a bug reported in Kodi's issue tracker: https://github.com/xbmc/xbmc/issues/16385

Due to the fact the youtube addon is reusing the language invoker, when a navigation exception is triggered Kodi is not signalled of the failure. Hence, the busy dialog keeps running indefinitely until it is manually closed by the user (e.g: by a back key press). This PR makes sure the `xbmcplugin.endofDirectory` is called with `succeeded=False` in such cases, allowing the languageinvoker thread to die.

The issue can be easily confirmed by executing:

```
curl -X POST   http://127.0.0.1:8080/jsonrpc   -H 'Content-Type: application/json'   -H 'Host: 127.0.0.1:8080'   -d '{"jsonrpc":"2.0","id":1,"method":"Player.Open","params":{"item":{"file":"plugin://plugin.video.youtube/fakeCallToDisplayAWindow"}}}'
```

Cheers