### PR TITLE
Update watch history only when use history

### DIFF
--- a/resources/lib/youtube_plugin/kodion/utils/player.py
+++ b/resources/lib/youtube_plugin/kodion/utils/player.py
@@ -51,6 +51,7 @@ class PlaybackMonitorThread(threading.Thread):
         playing_file = self.playback_json.get('playing_file')
         play_count = self.playback_json.get('play_count', 0)
         use_history = self.playback_json.get('use_history', False)
+        playback_history = self.playback_json.get('playback_history', False)
         playback_stats = self.playback_json.get('playback_stats')
         refresh_only = self.playback_json.get('refresh_only', False)
         try:
@@ -98,7 +99,7 @@ class PlaybackMonitorThread(threading.Thread):
         client = self.provider.get_client(self.context)
         is_logged_in = self.provider.is_logged_in()
 
-        if is_logged_in and report_url:
+        if is_logged_in and report_url and use_history:
             client.update_watch_history(self.video_id, report_url)
             self.context.log_debug('Playback start reported: |%s|' % self.video_id)
 
@@ -181,7 +182,7 @@ class PlaybackMonitorThread(threading.Thread):
                 self.update_times(last_total_time, last_current_time, last_segment_start, last_percent_complete)
                 break
 
-            if is_logged_in and report_url:
+            if is_logged_in and report_url and use_history:
                 if first_report or (p_waited >= report_interval):
                     if first_report:
                         first_report = False
@@ -226,7 +227,7 @@ class PlaybackMonitorThread(threading.Thread):
 
             p_waited += p_wait_time
 
-        if is_logged_in and report_url:
+        if is_logged_in and report_url and use_history:
             client.update_watch_history(self.video_id, report_url
                                         .format(st=format(self.segment_start, '.3f'),
                                                 et=format(self.current_time, '.3f'),
@@ -250,7 +251,7 @@ class PlaybackMonitorThread(threading.Thread):
         if self.percent_complete >= settings.get_play_count_min_percent():
             play_count = '1'
             self.current_time = 0.0
-            if is_logged_in and report_url:
+            if is_logged_in and report_url and use_history:
                 client.update_watch_history(self.video_id, report_url
                                             .format(st=format(self.total_time, '.3f'),
                                                     et=format(self.total_time, '.3f'),
@@ -258,7 +259,7 @@ class PlaybackMonitorThread(threading.Thread):
                 self.context.log_debug('Playback reported [%s] @ 100%% state=%s' % (self.video_id, state))
 
         else:
-            if is_logged_in and report_url:
+            if is_logged_in and report_url and use_history:
                 client.update_watch_history(self.video_id, report_url
                                             .format(st=format(self.current_time, '.3f'),
                                                     et=format(self.current_time, '.3f'),
@@ -270,7 +271,7 @@ class PlaybackMonitorThread(threading.Thread):
 
             refresh_only = True
 
-        if use_history:
+        if playback_history:
             self.context.get_playback_history().update(self.video_id, play_count, self.total_time,
                                                        self.current_time, self.percent_complete)
 

--- a/resources/lib/youtube_plugin/youtube/helper/yt_play.py
+++ b/resources/lib/youtube_plugin/youtube/helper/yt_play.py
@@ -75,7 +75,8 @@ def play_video(provider, context):
         video_item = VideoItem(title, video_stream['url'])
 
         incognito = str(context.get_param('incognito', False)).lower() == 'true'
-        use_history = not is_live and not screensaver and not incognito and settings.use_playback_history()
+        use_history = not is_live and not screensaver and not incognito
+        playback_history = use_history and settings.use_playback_history()
 
         video_item = utils.update_play_info(provider, context, video_id, video_item, video_stream, use_play_data=use_history)
 
@@ -104,6 +105,7 @@ def play_video(provider, context):
             "playing_file": video_item.get_uri(),
             "play_count": play_count,
             "use_history": use_history,
+            "playback_history": playback_history,
             "playback_stats": playback_stats,
             "seek_time": seek_time,
             "refresh_only": screensaver


### PR DESCRIPTION
With this modification the video is not added to the YouTube history when the video is played (by a connected user) in incognito or _Use playback history_ is disabled.