### PR TITLE
Add SponsorBlock integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ $RECYCLE.BIN/
 .pydevproject/
 
 __pycache__/
+venv/
 
 *.py[cod]
 

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1206,3 +1206,15 @@ msgstr ""
 msgctxt "#30730"
 msgid "Play (Ask for quality)"
 msgstr ""
+
+msgctxt "#30731"
+msgid "Integrations"
+msgstr ""
+
+msgctxt "#30732"
+msgid "SponsorBlock"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Skipped sponsor"
+msgstr ""

--- a/resources/lib/youtube_plugin/ext/sponsorblock.py
+++ b/resources/lib/youtube_plugin/ext/sponsorblock.py
@@ -1,0 +1,46 @@
+import traceback
+
+import requests
+
+from ..kodion import logger
+
+BASE_URL = "https://api.sponsor.ajay.app/api"
+
+GET_VIDEO_SPONSOR_TIMES = BASE_URL + "/getVideoSponsorTimes"
+
+STR_SKIPPED_SPONSOR = 30733
+
+
+def _parse_cutlist(raw_cutlist):
+    cutlist = []
+    for start, end in raw_cutlist:
+        if start >= end:
+            raise ValueError("start must be smaller than end")
+
+        cutlist.append({
+            "start": start,
+            "end": end,
+            "notification": STR_SKIPPED_SPONSOR
+        })
+
+    return cutlist
+
+
+def get_sponsor_cutlist(video_id):  # type: (str) -> Optional[List[dict]]
+    logger.log_debug("[SponsorBlock] getting sponsor times for %s" % video_id)
+    with requests.get(GET_VIDEO_SPONSOR_TIMES, params={"videoID": video_id}) as resp:
+        try:
+            data = resp.json()
+        except ValueError:
+            if resp.status_code == 404:
+                logger.log_debug("[SponsorBlock] no reported sponsor segments")
+            else:
+                logger.log_error("[SponserBlock] invalid response:\n%s" % traceback.format_exc())
+
+            return None
+
+    try:
+        return _parse_cutlist(data["sponsorTimes"])
+    except Exception:
+        logger.log_error("[SponserBlock] unable to parse sponsor times:\n%s" % traceback.format_exc())
+        return None

--- a/resources/lib/youtube_plugin/youtube/helper/yt_play.py
+++ b/resources/lib/youtube_plugin/youtube/helper/yt_play.py
@@ -16,11 +16,12 @@ import traceback
 import xbmcplugin
 
 from ... import kodion
+from ...ext import sponsorblock
 from ...kodion import constants
-from ...kodion.items import VideoItem
 from ...kodion.impl.xbmc.xbmc_items import to_playback_item
-from ...youtube.youtube_exceptions import YouTubeException
+from ...kodion.items import VideoItem
 from ...youtube.helper import utils, v3
+from ...youtube.youtube_exceptions import YouTubeException
 
 
 def play_video(provider, context):
@@ -105,6 +106,11 @@ def play_video(provider, context):
         except (ValueError, TypeError):
             pass
 
+        if settings.get_bool('ext.sponsorblock', False):
+            cutlist = sponsorblock.get_sponsor_cutlist(video_id)
+        else:
+            cutlist = None
+
         playback_json = {
             "video_id": video_id,
             "playing_file": video_item.get_uri(),
@@ -113,9 +119,9 @@ def play_video(provider, context):
             "playback_history": playback_history,
             "playback_stats": playback_stats,
             "seek_time": seek_time,
-            "refresh_only": screensaver
+            "refresh_only": screensaver,
+            "cutlist": cutlist,
         }
-
         context.get_ui().set_home_window_property('playback_json', json.dumps(playback_json))
 
         xbmcplugin.setResolvedUrl(handle=context.get_handle(), succeeded=True, listitem=item)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -128,6 +128,11 @@
         <setting id="youtube.api.config.page" type="bool" label="30632" default="false"/>
     </category>
 
+    <!-- integrations -->
+    <category label="30731">
+        <setting id="ext.sponsorblock" type="bool" label="30732" default="false"/>
+    </category>
+
     <!-- Maintenance -->
     <category label="30552">
         <setting id="kodion.maintain.clear.func" type="action" label="30555" action="RunPlugin(plugin://$ID/maintain/function_cache/clear/)"/>


### PR DESCRIPTION
Closes: #713
Please refer to the issue for information about what SponsorBlock is.

## Player cutlist support

To make this possible I modified the `PlaybackMonitorThread` to accept a cutlist (named after the new [`Player.Cutlist`](https://codedocs.xyz/xbmc/xbmc/modules__infolabels_boolean_conditions.html#Player_Cutlist) infolabel). The cutlist is a list of cut objects containing a start and end time and optionally a notification to show when the cut is performed. 

No cut is performed when the user manually seeks into a cut thus making it possible to "undo" a cut.
I might as well note that this should be easily extensible should the need arise.

## SponsorBlock integration

I added a new settings category for integrations. As far as I can tell this is the first external "integration" so, to me, it makes sense to add a separate category.
The integration, if enabled (of course it's disabled by default), creates a cutlist containing the sponsor segments and passes it to the playback monitor.